### PR TITLE
Format amount with 2 decimal places.

### DIFF
--- a/src/Models/CreateOrderRequestModel.php
+++ b/src/Models/CreateOrderRequestModel.php
@@ -132,7 +132,7 @@ class CreateOrderRequestModel implements JsonSerializable
     {
         $json = array();
         $json['accountIdentifier']  = $this->accountIdentifier;
-        $json['amount']             = $this->amount;
+        $json['amount']             = number_format($this->amount,2);
         $json['customerIdentifier'] = $this->customerIdentifier;
         $json['sendEmail']          = $this->sendEmail;
         $json['utid']               = $this->utid;


### PR DESCRIPTION
Avoids the following error from being thrown by the API when there is not an exact decimal representation of e.g. 0.7:

"errors" : [ {
    "path" : "amount",
    "message" : "Amount is larger than 6 digits or there are more than 2 digits for cents",
    "invalidValue" : 0.7000000000000001,
    "constraint" : "Digits"
  } ]