### PR TITLE
Adding missing content-type header

### DIFF
--- a/src/Controllers/OrdersController.php
+++ b/src/Controllers/OrdersController.php
@@ -134,7 +134,8 @@ class OrdersController extends BaseController
         //prepare headers
         $_headers = array (
             'user-agent'     => BaseController::USER_AGENT,
-            'Accept'         => 'application/json'
+            'Accept'         => 'application/json',
+            'content-type'      => 'application/json; charset=utf-8'
         );
 
         //set HTTP basic auth parameters


### PR DESCRIPTION
While attempting to use orders api in one of our applications, we encountered the missing header on the request.

Have updated the code, and requesting the merge to resolve the issue.